### PR TITLE
remove old code that tries to destroy member

### DIFF
--- a/routes/result.rb
+++ b/routes/result.rb
@@ -350,7 +350,6 @@ class MainApp < Sinatra::Base
           }
           @json["deleted_teams"].each{|x|
             t = ContestTeam[x]
-            t.members.destroy
             if not t.destroy then raise Exception.new("cannot destroy #{t.inspect}") end
           }
         else


### PR DESCRIPTION
DataMapper から Sequel に移行する際に消し損ねたコードっぽい．
現在はチームのメンバーが空でないとUI側で弾くようになっているのでこのコードは不要．