### PR TITLE
implement ContestPrize.after_destroy

### DIFF
--- a/models/result.rb
+++ b/models/result.rb
@@ -133,6 +133,13 @@ class ContestPrize < Sequel::Model(:contest_prizes)
       self.save_promotion_cache
     end
   end
+
+  def after_destroy
+    self.contest_user.update(point:0,point_local:0)
+    self.contest_class.event.update_cache_prizes
+    super
+  end
+
   def save_promotion_cache
     event = self.contest_class.event
     user_name = self.contest_user.name


### PR DESCRIPTION
Fixes: https://github.com/pjmtdw/kagetra/issues/40
入賞の削除のことは全然考慮されてなかったのでその大会の出場者のポイント数を0にするのと
大会結果の大会一覧の入賞データの更新をする処理を入れた．
昇級履歴はON CASCADE DELETEで自動的に削除される．