### PR TITLE
add function for refreshing contest_result_cache

### DIFF
--- a/models/result.rb
+++ b/models/result.rb
@@ -76,9 +76,17 @@ class ContestResultCache < Sequel::Model(:contest_result_caches)
   end
   def update_winlose
     x = self.event.result_users_dataset.select(
-      Sequel.function(:sum,:win).as("sum_win"),Sequel.function(:sum,:lose).as("sum_lose")
+      Sequel.function(:coalesce,Sequel.function(:sum,:win),0).as("sum_win"),Sequel.function(:coalesce,Sequel.function(:sum,:lose),0).as("sum_lose")
     ).first
     self.update(win:x[:sum_win],lose:x[:sum_lose])
+  end
+  def self.refresh_all
+   DB.transaction{
+     self.all.each{|res|
+       res.update_prizes
+       res.update_winlose
+     }
+   }
   end
 end
 


### PR DESCRIPTION
大会結果の大会一覧と実際の大会結果の表示の整合性が取れなくなったときに利用する．
contest_result_cache の中身を contest_result と同期させす．
使い方はサーバにログインして

    $ bundle exec tux
    >> ContestResultCache.refresh_all
